### PR TITLE
Fix registration layout and buttons

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -55,6 +55,11 @@
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
   width: 100%;
   max-width: 400px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  min-height: 480px;
+  box-sizing: border-box;
 }
 
 .login-form h2 {
@@ -103,6 +108,51 @@
 
 .login-button:hover {
   background-color: #357abd;
+}
+
+.auth-mode-toggle {
+  display: flex;
+  gap: 10px;
+}
+
+.auth-toggle-button {
+  flex: 1;
+  padding: 10px 16px;
+  border-radius: 8px;
+  border: 1px solid #dcdced;
+  background: #f7f8ff;
+  color: #4a4a68;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.25s ease;
+}
+
+.auth-toggle-button.active {
+  background: linear-gradient(120deg, #667eea, #764ba2);
+  color: #ffffff;
+  border-color: transparent;
+  box-shadow: 0 6px 18px rgba(102, 126, 234, 0.4);
+}
+
+.auth-toggle-button:hover:not(.active) {
+  border-color: #aab0ff;
+  color: #333366;
+}
+
+.email-field {
+  transition: opacity 0.25s ease;
+}
+
+.email-field.hidden {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.email-field.visible {
+  opacity: 1;
+  visibility: visible;
 }
 
 .logout-button,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -142,6 +142,22 @@ function App() {
     }
   };
 
+  const handleModeChange = (mode: 'login' | 'register') => {
+    if (mode === 'register') {
+      if (!isRegisterMode) {
+        setPassword('');
+      }
+      setIsRegisterMode(true);
+    } else {
+      if (isRegisterMode) {
+        setPassword('');
+        setEmail('');
+      }
+      setIsRegisterMode(false);
+    }
+    setError(null);
+  };
+
   const handleLogout = React.useCallback(() => {
     authAPI.logout();
     setIsLoggedIn(false);
@@ -229,6 +245,30 @@ function App() {
         </header>
         <main className="login-container">
           <div className="login-form">
+            <div
+              className="auth-mode-toggle"
+              role="tablist"
+              aria-label="Выбор режима авторизации"
+            >
+              <button
+                type="button"
+                role="tab"
+                aria-selected={!isRegisterMode}
+                className={`auth-toggle-button ${!isRegisterMode ? 'active' : ''}`}
+                onClick={() => handleModeChange('login')}
+              >
+                Вход
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={isRegisterMode}
+                className={`auth-toggle-button ${isRegisterMode ? 'active' : ''}`}
+                onClick={() => handleModeChange('register')}
+              >
+                Регистрация
+              </button>
+            </div>
             <h2>{isRegisterMode ? 'Регистрация' : 'Вход'}</h2>
             <form onSubmit={handleLogin}>
               <div className="form-group">
@@ -243,20 +283,21 @@ function App() {
                   autoComplete="username"
                 />
               </div>
-              {isRegisterMode && (
-                <div className="form-group">
-                  <label htmlFor="email">Email</label>
-                  <input
-                    id="email"
-                    type="email"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    placeholder="Введите email"
-                    required
-                    autoComplete="email"
-                  />
-                </div>
-              )}
+              <div
+                className={`form-group email-field ${isRegisterMode ? 'visible' : 'hidden'}`}
+                aria-hidden={!isRegisterMode}
+              >
+                <label htmlFor="email">Email</label>
+                <input
+                  id="email"
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="Введите email"
+                  required={isRegisterMode}
+                  autoComplete="email"
+                />
+              </div>
               <div className="form-group">
                 <label htmlFor="password">Пароль</label>
                 <input
@@ -289,30 +330,6 @@ function App() {
                 {error}
               </div>
             )}
-            <div style={{ marginTop: '15px', textAlign: 'center' }}>
-              <button 
-                type="button" 
-                onClick={() => {
-                  setIsRegisterMode(!isRegisterMode);
-                  setError(null);
-                  setPassword('');
-                }}
-                style={{
-                  background: 'transparent',
-                  border: 'none',
-                  color: '#667eea',
-                  padding: '8px 16px',
-                  cursor: 'pointer',
-                  textDecoration: 'underline',
-                  fontSize: '0.9rem'
-                }}
-              >
-                {isRegisterMode 
-                  ? 'Уже есть аккаунт? Войти' 
-                  : 'Нет аккаунта? Зарегистрироваться'
-                }
-              </button>
-            </div>
           </div>
         </main>
       </div>


### PR DESCRIPTION
Separate login and registration into distinct tab buttons and prevent layout shifts on the authentication screen.

---
<a href="https://cursor.com/background-agent?bcId=bc-70e348fb-0565-4381-b337-0eb780f1acb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-70e348fb-0565-4381-b337-0eb780f1acb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce tabbed login/register controls with animated email field and flex-based layout to prevent auth page shifts.
> 
> - **Auth UI**:
>   - Add tabbed mode switch with ARIA roles via `handleModeChange` and buttons styled as `auth-toggle-button` inside `auth-mode-toggle`.
>   - Replace conditional email field mount with visibility toggle (`email-field hidden/visible`) and conditional `required`.
>   - Reset relevant fields and errors on mode changes; tweak password placeholder/autocomplete per mode.
> - **Styles (`frontend/src/App.css`)**:
>   - Make `.login-form` a column flex container with gap, min-height, and `box-sizing` to stabilize layout.
>   - Add styles for `.auth-mode-toggle`, `.auth-toggle-button` (including `.active`/hover states).
>   - Add transition/visibility classes for `.email-field`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9e27c8ffa192757e029ce67de0eafbd80c316ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->