### PR TITLE
Проактивные сообщения по характеру тренера

### DIFF
--- a/backend/app/api/chats.py
+++ b/backend/app/api/chats.py
@@ -1191,13 +1191,32 @@ async def create_message(
             
             if not goal:
                 return user_message
-            
+
+            # Persist the user's coach personality on the goal so the background
+            # proactive service can match the tone (not just the live chat).
+            effective_trainer_id = trainer_id
+            if trainer_id or gender:
+                tone_sel, gender_sel = _normalize_trainer_selection(trainer_id, gender)
+                stored_id = f"{tone_sel}_{gender_sel}"
+                effective_trainer_id = stored_id
+                if getattr(goal, "coach_trainer_id", None) != stored_id:
+                    try:
+                        goal.coach_trainer_id = stored_id
+                        db.add(goal)
+                        db.commit()
+                    except Exception as exc:
+                        db.rollback()
+                        logger.warning("Failed to persist coach_trainer_id: %s", exc)
+            elif getattr(goal, "coach_trainer_id", None):
+                # No selection in this request — fall back to what the user chose earlier.
+                effective_trainer_id = goal.coach_trainer_id
+
             # Get agreements for context
             agreements = crud.agreement.get_pending_agreements(db, goal_id=chat.goal_id)
-            
+
             # Build messages for LLM
             chat_history = crud.chat.get_messages(db, chat_id=chat_id, skip=0, limit=20)  # Increased limit
-            system_prompt = build_system_prompt(goal, milestones, agreements, trainer_id, gender)
+            system_prompt = build_system_prompt(goal, milestones, agreements, effective_trainer_id, gender)
             llm_messages = [{"role": "system", "content": system_prompt}]
             
             # Add chat history (clean HTML markers for LLM)

--- a/backend/app/database/database.py
+++ b/backend/app/database/database.py
@@ -36,3 +36,31 @@ def get_db():
         yield db
     finally:
         db.close()
+
+
+def ensure_additive_columns():
+    """Lightweight, DB-agnostic safety net for additive columns when there is no
+    migration tool. Adds missing nullable columns so deploys don't require manual SQL.
+
+    Only ever ADDs nullable columns — never drops or alters existing data.
+    """
+    from sqlalchemy import inspect, text
+
+    # (table, column, SQL type) — keep types simple/portable.
+    required = [
+        ("goals", "coach_trainer_id", "VARCHAR"),
+    ]
+    try:
+        inspector = inspect(engine)
+        existing_tables = set(inspector.get_table_names())
+        with engine.begin() as conn:
+            for table, column, col_type in required:
+                if table not in existing_tables:
+                    continue
+                cols = {c["name"] for c in inspector.get_columns(table)}
+                if column in cols:
+                    continue
+                conn.execute(text(f'ALTER TABLE {table} ADD COLUMN {column} {col_type}'))
+                print(f"🧩 Added missing column {table}.{column}")
+    except Exception as exc:  # never block startup on this best-effort helper
+        print(f"⚠️  ensure_additive_columns skipped: {exc}")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -42,10 +42,12 @@ async def startup_event():
     """Create database tables and initialize services on startup."""
     # 1) Database initialization
     try:
-        from app.database.database import engine, Base
+        from app.database.database import engine, Base, ensure_additive_columns
         from app.models import goal, milestone, task, user, chat, report, agreement, device_token
         # Create all tables
         Base.metadata.create_all(bind=engine)
+        # Add any new additive columns on already-existing tables (no migration tool here)
+        ensure_additive_columns()
         print("✅ Database tables created/verified successfully")
     except Exception as e:
         import traceback

--- a/backend/app/models/goal.py
+++ b/backend/app/models/goal.py
@@ -15,6 +15,9 @@ class Goal(Base):
     frequency = Column(String, default="daily")  # daily, weekly, custom
     start_date = Column(DateTime(timezone=True))
     end_date = Column(DateTime(timezone=True))
+    # Coach personality chosen by the user (e.g. "strict_male", "gentle_female").
+    # Persisted so the background proactive service can match the tone, not just the live chat.
+    coach_trainer_id = Column(String, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
     

--- a/backend/app/services/coach_voice.py
+++ b/backend/app/services/coach_voice.py
@@ -1,0 +1,158 @@
+"""
+Coach voice — personality-aware proactive message banks.
+
+Proactive reminders used to be a single cute "owl" tone for everyone, ignoring
+the user's chosen trainer (strict / normal / gentle). This module provides
+tone-specific template banks so a strict user gets pressure, a gentle user gets
+warmth, and a normal user gets the balanced owl.
+
+Pure templates (no LLM dependency) → deterministic and testable offline.
+"""
+import random
+from typing import Optional
+
+VALID_TONES = {"strict", "normal", "gentle"}
+DEFAULT_TONE = "normal"
+
+
+def resolve_tone(coach_trainer_id: Optional[str]) -> str:
+    """Map a stored trainer id ('strict_male', 'gentle', ...) to a tone."""
+    if isinstance(coach_trainer_id, str) and coach_trainer_id.strip():
+        head = coach_trainer_id.strip().lower().split("_")[0]
+        if head in VALID_TONES:
+            return head
+    return DEFAULT_TONE
+
+
+# scenario -> tone -> list of templates.
+# Placeholders: {desc} agreement text, {hours} hours left, {days} days missed, {goal} goal title.
+VOICE = {
+    "remind": {
+        "strict": [
+            "⛓️ Договорённость: {desc}\nСрок — {hours} ч. Без оправданий. Делай и отчитайся.",
+            "🎯 {desc} — осталось {hours} ч.\nДисциплина решает. Где результат?",
+        ],
+        "normal": [
+            "🦉 Эй! Не забыл? Ты обещал: {desc}\n\nОсталось {hours} ч. Как прогресс?",
+            "⏰ Тик-так! {desc} — осталось {hours} ч.\n\nУспеваешь?",
+        ],
+        "gentle": [
+            "🌿 Лёгкое напоминание: {desc}.\nЕщё {hours} ч. Ты справишься, я рядом 💛",
+            "✨ Не торопись, но помни про {desc} — впереди {hours} ч.\nКак ты, всё ок?",
+        ],
+    },
+    "remind_urgent": {
+        "strict": [
+            "🚨 {desc} — {hours} ч. до срока.\nХватит тянуть. Соберись и закрывай пункт.",
+            "⛔ Время на исходе: {hours} ч. {desc}\nЭто проверка на дисциплину. Не сливай.",
+        ],
+        "normal": [
+            "🦉 Внимание! {desc}\n\nОсталось всего {hours} ч.! Ты точно успеешь?",
+            "⏰ {hours} ч. до дедлайна! {desc}\n\nВсё под контролем?",
+        ],
+        "gentle": [
+            "💛 Остался финишный отрезок: {hours} ч. на {desc}.\nСделай сколько сможешь — это уже победа.",
+            "🌸 Уже близко! {desc} — {hours} ч.\nЯ верю в тебя, давай мягко доведём до конца.",
+        ],
+    },
+    "miss1": {
+        "strict": [
+            "📉 Вчера — ноль активности.\nДисциплина начинается там, где не хочется. Возвращайся в режим. Сегодня.",
+        ],
+        "normal": [
+            "🦉 Эй, ты где? Я скучаю!\n\nВчера ты не заходил. Всё в порядке?",
+        ],
+        "gentle": [
+            "🌿 Вчера тебя не было — и это нормально.\nДавай тихонько вернёмся к цели? Я рядом 💛",
+        ],
+    },
+    "miss2": {
+        "strict": [
+            "📉 Два дня простоя подряд.\nТак цели не берут. Хватит откатываться — сегодня делаешь шаг. Обязательно.",
+        ],
+        "normal": [
+            "🦉 Эй-эй! Ты пропустил уже 2 дня подряд!\n\nЯ начинаю волноваться... Всё ок?",
+        ],
+        "gentle": [
+            "💛 Два дня паузы — бывает у каждого.\nНе вини себя. Один маленький шаг сегодня — и мы снова в потоке.",
+        ],
+    },
+    "miss3": {
+        "strict": [
+            "🛑 Три дня. Это уже не пауза, а сдача позиций.\nСоберись. Возвращаемся к режиму прямо сейчас, без обсуждений.",
+        ],
+        "normal": [
+            "🦉 ЭЙ! Ты пропустил 3 дня подряд! 😤\n\nМы же договаривались! Возвращайся!",
+        ],
+        "gentle": [
+            "🌸 Три дня вдали от цели. Я не сужу — я волнуюсь за тебя.\nДавай вернёмся вместе, по-маленьку. Ты не один.",
+        ],
+    },
+    "miss_week": {
+        "strict": [
+            "🛑 {days} дней простоя. Цель стоит на месте, а время уходит.\nЛибо сейчас пересобираем режим, либо она так и останется мечтой. Решай.",
+        ],
+        "normal": [
+            "🦉 Ты пропустил уже {days} дней. Я очень скучаю...\n\nДавай вернёмся? Я верю, что у тебя всё получится!",
+        ],
+        "gentle": [
+            "💛 {days} дней — это много, но дверь всегда открыта.\nНачать заново не стыдно. Сделаем первый маленький шаг сегодня?",
+        ],
+    },
+    "morning": {
+        "strict": [
+            "🌅 Подъём. Новый день — новый результат.\nЦель: {goal}. Первый шаг — сейчас, пока не передумал.",
+        ],
+        "normal": [
+            "🌅 Доброе утро! Готов к новому дню?\n\nОтличный день поработать над целью: {goal}",
+        ],
+        "gentle": [
+            "☀️ Доброе утро 💛 Пусть день будет добрым.\nКогда будешь готов — маленький шаг к цели «{goal}».",
+        ],
+    },
+    "morning_deadline": {
+        "strict": [
+            "🌅 Подъём. Сегодня срок: {desc}. Осталось {hours} ч.\nНикаких «потом». Закрывай.",
+        ],
+        "normal": [
+            "🌅 Доброе утро! Сегодня дедлайн по «{desc}»!\n\nОсталось {hours} ч. Успеешь?",
+        ],
+        "gentle": [
+            "☀️ Доброе утро 💛 Сегодня срок по «{desc}», ещё {hours} ч.\nСпокойно, по шагам — у тебя получится.",
+        ],
+    },
+    "checklist_intro": {
+        "strict": [
+            "🎯 Срок. Отчёт по факту: {desc}.\nБез приукрашиваний — что сделано?",
+        ],
+        "normal": [
+            "🦉 Та-дам! Время проверки!\n\nТы обещал: {desc}\n\nНу что, справился? Давай честно!",
+        ],
+        "gentle": [
+            "🌿 Мягкая сверка по «{desc}».\nЧто получилось — то и хорошо. Расскажи честно, без давления 💛",
+        ],
+    },
+    "missed_agreement": {
+        "strict": [
+            "📉 Срок по «{desc}» прошёл. Ответа нет.\nЭто и есть цена недисциплины. Признаём и пересобираем план. Что дальше?",
+        ],
+        "normal": [
+            "🦉 Хм... Дедлайн по «{desc}» прошёл, а ответа я не получил...\n\nЧто случилось? 😔",
+        ],
+        "gentle": [
+            "💛 Срок по «{desc}» прошёл — и это не конец света.\nБывает. Давай аккуратно вернёмся и попробуем снова?",
+        ],
+    },
+}
+
+
+def pick(scenario: str, tone: Optional[str], **ctx) -> str:
+    """Pick a tone-appropriate template for a scenario and fill placeholders."""
+    t = tone if tone in VALID_TONES else DEFAULT_TONE
+    bank = VOICE.get(scenario, {})
+    variants = bank.get(t) or bank.get(DEFAULT_TONE) or [""]
+    template = random.choice(variants)
+    try:
+        return template.format(**ctx)
+    except (KeyError, IndexError):
+        return template

--- a/backend/app/services/proactive_service.py
+++ b/backend/app/services/proactive_service.py
@@ -14,9 +14,16 @@ from app import crud, schemas
 from app.models.agreement import AgreementStatus, Agreement
 from app.models.chat import Message, Chat
 from app.models.goal import Goal
+from app.services import coach_voice
 
 # Store for tracking active chats (in production, use Redis)
 active_chats: dict = {}
+
+
+def _goal_tone(db: Session, goal_id: int) -> str:
+    """Resolve the coach tone (strict/normal/gentle) chosen for a goal."""
+    goal = db.query(Goal).filter(Goal.id == goal_id).first()
+    return coach_voice.resolve_tone(getattr(goal, "coach_trainer_id", None) if goal else None)
 
 # Track last proactive message per chat to avoid spam
 last_proactive_messages: Dict[int, datetime] = {}
@@ -145,73 +152,51 @@ async def check_and_send_reminders(db: Session):
     for agreement in upcoming:
         # Find the chat for this goal
         chat = db.query(Chat).filter(Chat.goal_id == agreement.goal_id).first()
-        
+
         if not chat:
             continue
-        
+
+        tone = _goal_tone(db, agreement.goal_id)
         hours_left = (agreement.deadline - now).total_seconds() / 3600
-        
+        desc = agreement.description
+
         # Multiple reminders based on time left
         # 1. First reminder: 24 hours before
         if 20 <= hours_left <= 24 and not agreement.reminder_sent:
-            reminders_24h = [
-                f"🦉 Эй! Не забыл? Ты обещал: {agreement.description}\n\nОсталось {int(hours_left)} часов. Как прогресс?",
-                f"👀 Я слежу за тобой! До дедлайна {int(hours_left)} ч.\n\nЗадача: {agreement.description}\n\nУспеваешь?",
-                f"⏰ Тик-так! {agreement.description} — осталось {int(hours_left)} часов!\n\nНе подведи меня 🦉",
-                f"🔔 Напоминалка! Мы договаривались: {agreement.description}\n\nВремя идёт... {int(hours_left)} ч. до дедлайна!"
-            ]
-            reminder_content = random.choice(reminders_24h)
+            reminder_content = coach_voice.pick("remind", tone, desc=desc, hours=int(hours_left))
             suggestions = ["Уже делаю!", "Сделаю сегодня", "Нужна помощь"]
             reminder_content += f"\n\n<!--SUGGESTIONS:{json.dumps(suggestions, ensure_ascii=False)}-->"
-            
+
             await send_proactive_message(db, chat.id, reminder_content, min_interval=0)
             crud.agreement.mark_reminder_sent(db, agreement.id)
-            print(f"✅ 24h reminder sent for agreement {agreement.id}")
-        
+            print(f"✅ 24h reminder sent for agreement {agreement.id} (tone={tone})")
+
         # 2. Second reminder: 12 hours before (more urgent!)
         elif 10 <= hours_left <= 12:
-            reminders_12h = [
-                f"🦉 Эй-эй! Время идёт! Ты обещал: {agreement.description}\n\nОсталось всего {int(hours_left)} часов! Как дела?",
-                f"⏰ {int(hours_left)} часов до дедлайна! {agreement.description}\n\nТы же не хочешь меня расстроить? 🦉",
-                f"👀 Я всё ещё слежу! {agreement.description} — через {int(hours_left)} ч. дедлайн!\n\nВсё под контролем?",
-                f"🔔 Напоминаю ещё раз! {agreement.description}\n\nОсталось {int(hours_left)} часов. Не забудь!"
-            ]
-            reminder_content = random.choice(reminders_12h)
+            reminder_content = coach_voice.pick("remind", tone, desc=desc, hours=int(hours_left))
             suggestions = ["В процессе!", "Скоро начну", "Всё под контролем"]
             reminder_content += f"\n\n<!--SUGGESTIONS:{json.dumps(suggestions, ensure_ascii=False)}-->"
-            
+
             await send_proactive_message(db, chat.id, reminder_content, min_interval=60)
-            print(f"✅ 12h reminder sent for agreement {agreement.id}")
-        
+            print(f"✅ 12h reminder sent for agreement {agreement.id} (tone={tone})")
+
         # 3. Third reminder: 6 hours before (very urgent!)
         elif 4 <= hours_left <= 6:
-            reminders_6h = [
-                f"🦉 ЭЙ! Внимание! {agreement.description}\n\nОсталось всего {int(hours_left)} часов! Ты точно успеешь?",
-                f"⏰ {int(hours_left)} часов! {agreement.description}\n\nЯ начинаю волноваться... 🦉 Всё ок?",
-                f"👀 Последний рывок! {agreement.description} — через {int(hours_left)} ч.!\n\nКак прогресс?",
-                f"🔔 Срочно! {agreement.description}\n\nОсталось {int(hours_left)} часов. Не подведи!"
-            ]
-            reminder_content = random.choice(reminders_6h)
+            reminder_content = coach_voice.pick("remind_urgent", tone, desc=desc, hours=int(hours_left))
             suggestions = ["Почти готово!", "Сейчас доделаю", "Нужна помощь"]
             reminder_content += f"\n\n<!--SUGGESTIONS:{json.dumps(suggestions, ensure_ascii=False)}-->"
-            
+
             await send_proactive_message(db, chat.id, reminder_content, min_interval=60)
-            print(f"✅ 6h reminder sent for agreement {agreement.id}")
-        
+            print(f"✅ 6h reminder sent for agreement {agreement.id} (tone={tone})")
+
         # 4. Last reminder: 2 hours before (PANIC MODE!)
         elif 1 <= hours_left <= 2:
-            reminders_2h = [
-                f"🦉 ЭЙ-ЭЙ-ЭЙ! {agreement.description}\n\nОСТАЛОСЬ {int(hours_left)} ЧАСА! Ты где?!",
-                f"⏰ {int(hours_left)} часа до дедлайна! {agreement.description}\n\nЯ очень волнуюсь... 🦉 Ты успеешь?",
-                f"👀 ПОСЛЕДНИЙ ШАНС! {agreement.description} — через {int(hours_left)} ч.!\n\nВсё под контролем?",
-                f"🔔 СРОЧНО! {agreement.description}\n\nОсталось {int(hours_left)} часа. Не забудь!"
-            ]
-            reminder_content = random.choice(reminders_2h)
+            reminder_content = coach_voice.pick("remind_urgent", tone, desc=desc, hours=int(hours_left))
             suggestions = ["Почти готово!", "Сейчас доделаю", "Нужна помощь"]
             reminder_content += f"\n\n<!--SUGGESTIONS:{json.dumps(suggestions, ensure_ascii=False)}-->"
-            
+
             await send_proactive_message(db, chat.id, reminder_content, min_interval=30)
-            print(f"✅ 2h reminder sent for agreement {agreement.id}")
+            print(f"✅ 2h reminder sent for agreement {agreement.id} (tone={tone})")
 
 
 async def check_and_send_deadline_checklists(db: Session):
@@ -235,12 +220,9 @@ async def check_and_send_deadline_checklists(db: Session):
             ]
         }
         
-        intros = [
-            f"🦉 Та-дам! Время проверки!\n\nТы обещал: {agreement.description}\n\nНу что, справился? Давай честно!",
-            f"⏰ Дедлайн! Как там с задачей?\n\n📝 {agreement.description}\n\nПокажи результат! 👇",
-            f"🔔 Время пришло! Мы договаривались: {agreement.description}\n\nРассказывай, что получилось!"
-        ]
-        content = random.choice(intros) + f"\n\n<!--CHECKLIST:{json.dumps(checklist_data, ensure_ascii=False)}-->"
+        tone = _goal_tone(db, agreement.goal_id)
+        intro = coach_voice.pick("checklist_intro", tone, desc=agreement.description)
+        content = intro + f"\n\n<!--CHECKLIST:{json.dumps(checklist_data, ensure_ascii=False)}-->"
         
         await send_proactive_message(db, chat.id, content, min_interval=0)
         crud.agreement.mark_checklist_sent(db, agreement.id)
@@ -280,62 +262,40 @@ async def check_and_send_missed_days_messages(db: Session):
         if is_chat_active(chat.id, minutes=60):
             continue
         
+        tone = _goal_tone(db, goal.id)
+
         # Different messages based on days missed
         if days_since == 1:
-            # First day missed - gentle reminder
-            messages = [
-                "🦉 Эй, ты где? Я скучаю!\n\nВчера ты не заходил. Всё в порядке?",
-                "👀 Я заметил, что ты вчера не появлялся...\n\nВсё хорошо? Может, продолжим?",
-                "🦉 Привет! Вчера тебя не было видно.\n\nКак дела с целью? Давай вернёмся к ней!"
-            ]
-            content = random.choice(messages)
+            content = coach_voice.pick("miss1", tone)
             suggestions = ["Вернулся!", "Был занят", "Продолжаю"]
             content += f"\n\n<!--SUGGESTIONS:{json.dumps(suggestions, ensure_ascii=False)}-->"
-            
+
             await send_proactive_message(db, chat.id, content, min_interval=120)
-            print(f"✅ 1-day missed message sent for chat {chat.id}")
-        
+            print(f"✅ 1-day missed message sent for chat {chat.id} (tone={tone})")
+
         elif days_since == 2:
-            # Second day - more concerned
-            messages = [
-                "🦉 Эй-эй! Ты пропустил уже 2 дня подряд!\n\nЯ начинаю волноваться... Всё ок?",
-                "👀 Два дня без тебя! Это не похоже на тебя...\n\nЧто случилось? Может, нужна помощь?",
-                "🦉 Хм, ты пропустил 2 дня. Я немного расстроен... 😔\n\nДавай вернёмся к цели?"
-            ]
-            content = random.choice(messages)
+            content = coach_voice.pick("miss2", tone)
             suggestions = ["Вернулся!", "Был занят", "Нужна помощь"]
             content += f"\n\n<!--SUGGESTIONS:{json.dumps(suggestions, ensure_ascii=False)}-->"
-            
+
             await send_proactive_message(db, chat.id, content, min_interval=120)
-            print(f"✅ 2-day missed message sent for chat {chat.id}")
-        
+            print(f"✅ 2-day missed message sent for chat {chat.id} (tone={tone})")
+
         elif days_since == 3:
-            # Third day - Duolingo style "shaming" (but friendly!)
-            messages = [
-                "🦉 ЭЙ! Ты пропустил 3 дня подряд! 😤\n\nЯ очень расстроен... Мы же договаривались!",
-                "👀 Три дня без тебя! Это уже серьёзно...\n\nЯ верю в тебя, но нужно возвращаться! 🦉",
-                "🦉 Хм, 3 дня пропущено. Я начинаю думать, что ты меня забыл... 😢\n\nВернись, пожалуйста!"
-            ]
-            content = random.choice(messages)
+            content = coach_voice.pick("miss3", tone)
             suggestions = ["Вернулся!", "Извини", "Продолжаю"]
             content += f"\n\n<!--SUGGESTIONS:{json.dumps(suggestions, ensure_ascii=False)}-->"
-            
+
             await send_proactive_message(db, chat.id, content, min_interval=120)
-            print(f"✅ 3-day missed message sent for chat {chat.id}")
-        
+            print(f"✅ 3-day missed message sent for chat {chat.id} (tone={tone})")
+
         elif days_since >= 7:
-            # Week missed - very concerned but encouraging
-            messages = [
-                f"🦉 Эй... Ты пропустил уже {days_since} дней. Я очень скучаю...\n\nДавай вернёмся? Я верю, что у тебя всё получится!",
-                f"👀 {days_since} дней без тебя... Это долго.\n\nНо я не сдаюсь! Давай начнём заново? 🦉",
-                f"🦉 Я всё ещё здесь! Ты пропустил {days_since} дней, но я не теряю надежду.\n\nВернись, пожалуйста. Я помогу тебе!"
-            ]
-            content = random.choice(messages)
+            content = coach_voice.pick("miss_week", tone, days=days_since)
             suggestions = ["Вернулся!", "Начну заново", "Нужна помощь"]
             content += f"\n\n<!--SUGGESTIONS:{json.dumps(suggestions, ensure_ascii=False)}-->"
-            
+
             await send_proactive_message(db, chat.id, content, min_interval=180)
-            print(f"✅ {days_since}-day missed message sent for chat {chat.id}")
+            print(f"✅ {days_since}-day missed message sent for chat {chat.id} (tone={tone})")
 
 
 async def check_and_send_morning_motivations(db: Session):
@@ -377,24 +337,19 @@ async def check_and_send_morning_motivations(db: Session):
         
         # Get pending agreements
         pending_agreements = crud.agreement.get_pending_agreements(db, goal.id)
-        
-        morning_messages = [
-            f"🌅 Доброе утро! Готов к новому дню?\n\nСегодня отличный день, чтобы поработать над целью: {goal.title}",
-            f"🦉 Привет! Утро — лучшее время для продуктивности!\n\nКак дела с целью '{goal.title}'?",
-            f"☀️ Доброе утро! Я проснулся и сразу подумал о тебе!\n\nДавай сегодня сделаем шаг к цели: {goal.title}"
-        ]
-        
+        tone = _goal_tone(db, goal.id)
+
+        content = coach_voice.pick("morning", tone, goal=goal.title)
+
         if pending_agreements:
             agreement = pending_agreements[0]
             hours_left = (agreement.deadline - now).total_seconds() / 3600
             if hours_left <= 24:
-                morning_messages = [
-                    f"🌅 Доброе утро! Напоминаю: сегодня дедлайн по '{agreement.description}'!\n\nОсталось {int(hours_left)} часов. Успеешь?",
-                    f"🦉 Утро! Сегодня важный день — дедлайн по '{agreement.description}'!\n\nОсталось {int(hours_left)} часов. Всё под контролем?",
-                    f"☀️ Доброе утро! Не забудь: '{agreement.description}' — дедлайн через {int(hours_left)} ч.!\n\nГотов?"
-                ]
-        
-        content = random.choice(morning_messages)
+                content = coach_voice.pick(
+                    "morning_deadline", tone,
+                    desc=agreement.description, hours=int(hours_left),
+                )
+
         suggestions = ["Доброе утро!", "Начну сейчас", "Позже"]
         content += f"\n\n<!--SUGGESTIONS:{json.dumps(suggestions, ensure_ascii=False)}-->"
         
@@ -420,12 +375,8 @@ async def check_and_mark_missed_agreements(db: Session):
         # Send "shaming" message
         chat = db.query(Chat).filter(Chat.goal_id == agreement.goal_id).first()
         if chat:
-            missed_messages = [
-                f"🦉 Хм... Дедлайн по '{agreement.description}' прошёл, а я не получил ответа...\n\nЧто случилось? 😔",
-                f"👀 Я заметил, что дедлайн по '{agreement.description}' прошёл...\n\nВсё в порядке? Может, нужно было больше времени?",
-                f"🦉 Эй, дедлайн по '{agreement.description}' прошёл...\n\nЯ немного расстроен, но понимаю, что бывает. Что дальше?"
-            ]
-            content = random.choice(missed_messages)
+            tone = _goal_tone(db, agreement.goal_id)
+            content = coach_voice.pick("missed_agreement", tone, desc=agreement.description)
             suggestions = ["Извини, забыл", "Нужна помощь", "Продолжаю"]
             content += f"\n\n<!--SUGGESTIONS:{json.dumps(suggestions, ensure_ascii=False)}-->"
             


### PR DESCRIPTION
## Проблема
Проактивные напоминания/пинки были одним «совиным» тоном для всех — выбранный характер (strict/normal/gentle) игнорировался даже после PR #13 (тот включил тон только в живом чате, не в фоне).

## Что меняется
- Новый `app/services/coach_voice.py`: банки реплик под каждый характер (strict/normal/gentle) для сценариев reminder / missed-days / morning / checklist / missed-agreement. Чистые шаблоны, без зависимости от LLM, тестируются оффлайн.
- Выбор коуча персистится в `Goal.coach_trainer_id`, чтобы фоновый сервис знал тон (а не только живой чат).
- `ensure_additive_columns()`: безопасное авто-добавление новой nullable-колонки при старте без миграционного инструмента (SQLite + Postgres).
- `proactive_service` резолвит тон по цели и берёт соответствующий голос.

## Проверка (оффлайн)
- strict vs gentle различаются во всех сценариях;
- тон корректно резолвится из сохранённой цели;
- приложение стартует, колонка авто-добавляется, debug-эндпоинт резолвит strict_male → strict/male.

Файлы: coach_voice (new), proactive_service, chats, goal, database, main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)