### PR TITLE
render: switch LLM to OpenRouter, drop dead trainer-test env

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -17,21 +17,15 @@ services:
       - key: SECRET_KEY
         generateValue: true
       - key: LLM_PROVIDER
-        value: groq
+        value: openrouter
       - key: LLM_API_KEY
         sync: false  # Set manually in Render dashboard
       - key: LLM_MODEL
-        value: llama-3.1-8b-instant
+        value: meta-llama/llama-3.3-70b-instruct:free
       - key: FCM_SERVER_KEY
         sync: false  # Set manually in Render dashboard
       - key: PORT
         value: 8000
-      - key: TRAINER_PROMPT_TEST_MODE
-        value: "true"
-      - key: TRAINER_PROMPT_TEST_FORCE_ID
-        value: strict
-      - key: TRAINER_PROMPT_TEST_FORCE_GENDER
-        value: male
 
   # Frontend (React Static Site)
   - type: web


### PR DESCRIPTION
Sync render.yaml with the dashboard: provider=openrouter, free model, remove TRAINER_PROMPT_TEST_* (code no longer reads them). Prevents blueprint drift back to groq.

🤖 Generated with [Claude Code](https://claude.com/claude-code)