### PR TITLE
web: send selected trainer_id to backend (fix differentiator end-to-end)

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -342,7 +342,18 @@ export const chatsAPI = {
   },
 
   sendMessage: async (chatId: number, content: string, sender: 'user' | 'ai', debugMode: boolean = false): Promise<Message> => {
-    const url = `/api/chats/${chatId}/messages/?debug_mode=${debugMode}`;
+    // Pass the user's chosen coach personality so the backend tone matches the selection.
+    // Without this, the backend falls back to the neutral default and the differentiator is lost.
+    let trainerParam = '';
+    try {
+      const selectedTrainerId = localStorage.getItem('selectedTrainerId');
+      if (selectedTrainerId) {
+        trainerParam = `&trainer_id=${encodeURIComponent(selectedTrainerId)}`;
+      }
+    } catch (e) {
+      // localStorage may be unavailable; fall back to backend default silently.
+    }
+    const url = `/api/chats/${chatId}/messages/?debug_mode=${debugMode}${trainerParam}`;
     const message = await apiRequest<Message>(url, {
       method: 'POST',
       body: JSON.stringify({ content, sender }),


### PR DESCRIPTION
Coach personality lived only in the frontend and never reached the message endpoint, so prod always used the neutral default. sendMessage now passes trainer_id from localStorage so strict/gentle actually drives the coach for real web users.

Single file: frontend/src/services/api.ts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)