### PR TITLE
render: LLM_MODEL -> openai/gpt-4o-mini (reliability)

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -21,7 +21,7 @@ services:
       - key: LLM_API_KEY
         sync: false  # Set manually in Render dashboard
       - key: LLM_MODEL
-        value: meta-llama/llama-3.3-70b-instruct:free
+        value: openai/gpt-4o-mini
       - key: FCM_SERVER_KEY
         sync: false  # Set manually in Render dashboard
       - key: PORT


### PR DESCRIPTION
Free model rate-limits (429). Switch to cheap reliable gpt-4o-mini on OpenRouter; matches dashboard env. Requires OpenRouter credit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)