### PR TITLE
render: LLM_MODEL -> llama-3.3-70b (region-available, reliable)

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -21,7 +21,7 @@ services:
       - key: LLM_API_KEY
         sync: false  # Set manually in Render dashboard
       - key: LLM_MODEL
-        value: openai/gpt-4o-mini
+        value: meta-llama/llama-3.3-70b-instruct
       - key: FCM_SERVER_KEY
         sync: false  # Set manually in Render dashboard
       - key: PORT


### PR DESCRIPTION
OpenAI/Anthropic/Google blocked for billing region. Switch to paid Meta llama-3.3-70b on existing OpenRouter credits; no free-tier 429. Matches dashboard env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)