### PR TITLE
stats: public users-count endpoint (100-users series)

### DIFF
--- a/backend/app/api/api.py
+++ b/backend/app/api/api.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter
-from app.api import users, goals, milestones, tasks, chats, reports, ai, push, tgbot
+from app.api import users, goals, milestones, tasks, chats, reports, ai, push, tgbot, stats
 
 router = APIRouter()
 
@@ -12,3 +12,4 @@ router.include_router(reports.router, prefix="/reports", tags=["reports"])
 router.include_router(ai.router, prefix="/ai", tags=["ai"])
 router.include_router(push.router, prefix="/push", tags=["push"])
 router.include_router(tgbot.router, prefix="/tgbot", tags=["tgbot"])
+router.include_router(stats.router, prefix="/stats", tags=["stats"])

--- a/backend/app/api/stats.py
+++ b/backend/app/api/stats.py
@@ -1,0 +1,34 @@
+"""Public stats endpoints — lightweight metrics for the build-in-public series.
+
+Exposes a read-only user count so progress toward the first-100-users goal can be
+shown live on camera and in the Telegram channel.
+"""
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from app.database.database import get_db
+from app.models.user import User
+
+# Usernames created by automated e2e checks — excluded from the public count.
+TEST_PREFIXES = ("e2e_", "v_", "test_", "test")
+
+router = APIRouter()
+
+# Headline goal for the launch series ("first 100 users").
+USERS_GOAL = 100
+
+
+@router.get("/users-count")
+def users_count(db: Session = Depends(get_db)):
+    """Total registered users + progress toward the launch goal."""
+    q = db.query(User)
+    for pref in TEST_PREFIXES:
+        q = q.filter(~User.username.like(f"{pref}%"))
+    total = q.count()
+    remaining = max(USERS_GOAL - total, 0)
+    pct = round(min(total / USERS_GOAL * 100, 100), 1) if USERS_GOAL else 0
+    return {
+        "users": total,
+        "goal": USERS_GOAL,
+        "remaining": remaining,
+        "progress_pct": pct,
+    }


### PR DESCRIPTION
GET /api/stats/users-count → {users, goal:100, remaining, progress_pct}. Excludes e2e test accounts. Powers the build-in-public progress counter on camera and in Telegram.

🤖 Generated with [Claude Code](https://claude.com/claude-code)